### PR TITLE
Kube repo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ export CRIO_VERSION=1.30
 cat <<EOF | sudo tee /etc/apt/sources.list.d/cri-o.sources
 Enabled: yes
 Types: deb
-URIs: https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/
+URIs: https://pkgs.k8s.io/addons:/cri-o:/stable:/v$CRIO_VERSION/deb/
 Suites: /
 Signed-By: /usr/share/keyrings/cri-o-apt-keyring.gpg
 EOF
 ```
 
 ```bash
-curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/v$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
 ```
 
 **3. Update apt and install CRI-O and CRI-O specific runC**

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sudo chown -R $(id -u):$(id -g) $HOME/.kube/config
 
 **1. Install Calcio operator**
 ```bash
-kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/tigera-operator.yaml
 ```
 
 **2. Apply basic Calico IPIP config
@@ -224,7 +224,7 @@ _Note: You can use kube-vip instead of MetalLB as a Cloud Provider to manage ser
 _Check for latest version [here](https://github.com/metallb/metallb)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
 ```
 
 Config:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ sudo chown -R $(id -u):$(id -g) $HOME/.kube/config
 
 **1. Install Calcio operator**
 ```bash
-kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/tigera-operator.yaml
 ```
 
 **2. Apply basic Calico IPIP config
@@ -214,7 +214,7 @@ sudo kubeadm token create --print-join-command
 _Check for latest version [here](https://github.com/longhorn/longhorn)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.4.0/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.5.3/deploy/longhorn.yaml
 ```
 
 ## Install MetalLB and Contour
@@ -224,7 +224,7 @@ _Note: You can use kube-vip instead of MetalLB as a Cloud Provider to manage ser
 _Check for latest version [here](https://github.com/metallb/metallb)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
 ```
 
 Config:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ EOF
 **1. Set variables for subsequent commands. OS and VERSION are specific to CRI-O URLs**
 ```bash
 export OS=xUbuntu_22.04
-export VERSION=1.28
+export VERSION=1.31
 ```
 
 **2. Configure apt certs and repos**
@@ -264,7 +264,7 @@ Check https://github.com/kubernetes/kubernetes/releases for available releases
 For bins:
 
 ```bash
-apt-cache policy kubeadm | grep <version, e.g. 1.31.0>
+apt-cache policy kubeadm
 ```
 
 **Step 2. Set environment vars**

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ sudo kubeadm token create --print-join-command
 _Check for latest version [here](https://github.com/longhorn/longhorn)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.5.3/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.6.2/deploy/longhorn.yaml
 ```
 
 ## Install MetalLB and Contour
@@ -224,7 +224,7 @@ _Note: You can use kube-vip instead of MetalLB as a Cloud Provider to manage ser
 _Check for latest version [here](https://github.com/metallb/metallb)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14/config/manifests/metallb-native.yaml
 ```
 
 Config:
@@ -264,17 +264,17 @@ Check https://github.com/kubernetes/kubernetes/releases for available releases
 For bins:
 
 ```bash
-apt-cache policy kubeadm | grep <version, e.g. 1.26>
+apt-cache policy kubeadm | grep <version, e.g. 1.31.0>
 ```
 
 **Step 2. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.26.2>"
+K8S_RELEASE="<Release version, e.g. v1.31.0>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.26.2-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
 ```
 
 ```bash
@@ -316,11 +316,11 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.26.2>"
+K8S_RELEASE="<Release version, e.g. v1.31.0>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.26.2-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
 ```
 
 ```bash
@@ -361,7 +361,7 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.26.2-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
 ```
 
 **Step 2. Update bins**

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ sudo kubeadm upgrade plan $K8S_RELEASE
 **Step 3. Update bins**
 
 ```bash
-sudo apt-get update && sudo apt-get -y –allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
+sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```
 
 **Step 4. Perform Cordon, drain, upgrade, and uncordon**
@@ -367,5 +367,5 @@ KUBEADM_VER="<kubeadm version, e.g. 1.26.2-00>"
 **Step 2. Update bins**
 
 ```bash
-sudo apt-get update && sudo apt-get -y –allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
+sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ EOF
 
 ## Install CRI-O on Ubuntu
 
-**1. Set variables for subsequent commands. OS and VERSION are specific to CRI-O URLs**
+**1. Set variables for subsequent commands**
 ```bash
 export KUBERNETES_VERSION=1.31
 export CRIO_VERSION=1.30
@@ -82,7 +82,7 @@ EOF
 curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/v$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
 ```
 
-**3. Update apt and install CRI-O and CRI-O specific runC**
+**3. Update apt and install CRI-O**
 ```bash
 sudo apt update && sudo apt -y install cri-o
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ EOF
 **1. Set variables for subsequent commands. OS and VERSION are specific to CRI-O URLs**
 ```bash
 export OS=xUbuntu_22.04
-export VERSION=1.26
+export VERSION=1.28
 ```
 
 **2. Configure apt certs and repos**

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ sudo apt-get install -y apt-transport-https ca-certificates curl
 
 **3. Configure apt-get cert and repo**
 ```bash
-sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-apt-keyring.gpg
 ```
 ```bash
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 ```
 
 **4. Update apt and install `kubelet`, `kubeadm`, and `kubectl`**

--- a/README.md
+++ b/README.md
@@ -63,30 +63,28 @@ EOF
 
 **1. Set variables for subsequent commands. OS and VERSION are specific to CRI-O URLs**
 ```bash
-export OS=xUbuntu_22.04
-export VERSION=1.31
+export KUBERNETES_VERSION=1.31
+export CRIO_VERSION=1.30
 ```
 
 **2. Configure apt certs and repos**
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/libcontainers-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+cat <<EOF | sudo tee /etc/apt/sources.list.d/cri-o.sources
+Enabled: yes
+Types: deb
+URIs: https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/
+Suites: /
+Signed-By: /usr/share/keyrings/cri-o-apt-keyring.gpg
+EOF
 ```
 
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/libcontainers-crio-archive-keyring.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:$VERSION.list
-```
-
-```bash
-curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/libcontainers-archive-keyring.gpg
-```
-
-```bash
-curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
 ```
 
 **3. Update apt and install CRI-O and CRI-O specific runC**
 ```bash
-sudo apt update && sudo apt -y install cri-o cri-o-runc
+sudo apt update && sudo apt -y install cri-o
 ```
 
 **4. Enable and start CRI-O service**
@@ -99,7 +97,6 @@ sudo systemctl enable --now crio
 ```bash
 sudo apt install cri-tools
 sudo systemctl status crio
-sudo crio-status info
 sudo crictl info
 ```
 
@@ -122,10 +119,16 @@ sudo apt-get install -y apt-transport-https ca-certificates curl
 
 **3. Configure apt-get cert and repo**
 ```bash
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-apt-keyring.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-key.gpg
 ```
 ```bash
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+cat <<EOF | sudo tee /etc/apt/sources.list.d/kubernetes.sources
+Enabled: yes
+Types: deb
+URIs: https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION/deb/
+Suites: /
+Signed-By: /usr/share/keyrings/kubernetes-key.gpg
+EOF
 ```
 
 **4. Update apt and install `kubelet`, `kubeadm`, and `kubectl`**

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ sudo apt-get install -y apt-transport-https ca-certificates curl
 
 **3. Configure apt-get cert and repo**
 ```bash
-sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-apt-keyring.gpg
 ```
 ```bash
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 ```
 
 **4. Update apt and install `kubelet`, `kubeadm`, and `kubectl`**

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ sudo kubeadm upgrade plan $K8S_RELEASE
 **Step 4. Update bins**
 
 ```bash
-sudo apt-get update && sudo apt-get -y –allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
+sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```
 
 **Step 5. Perform Cordon, drain, upgrade, and uncordon**
@@ -333,7 +333,7 @@ sudo kubeadm upgrade plan $K8S_RELEASE
 **Step 3. Update bins**
 
 ```bash
-sudo apt-get update && sudo apt-get -y –allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
+sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```
 
 **Step 4. Perform Cordon, drain, upgrade, and uncordon**
@@ -365,5 +365,5 @@ KUBEADM_VER="<kubeadm version, e.g. 1.26.2-00>"
 **Step 2. Update bins**
 
 ```bash
-sudo apt-get update && sudo apt-get -y –allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
+sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ sudo chown -R $(id -u):$(id -g) $HOME/.kube/config
 
 **1. Install Calcio operator**
 ```bash
-kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/tigera-operator.yaml
 ```
 
 **2. Apply basic Calico IPIP config
@@ -213,7 +213,7 @@ sudo kubeadm token create --print-join-command
 _Check for latest version, this version is latest of this edit_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.4.0/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v1.5.3/deploy/longhorn.yaml
 ```
 
 ## Install MetalLB and Contour
@@ -222,7 +222,7 @@ _Note: You can use kube-vip instead of MetalLB as a Cloud Provider to manage ser
 
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.12/config/manifests/metallb-native.yaml
 ```
 
 Config:

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ export CRIO_VERSION=1.30
 cat <<EOF | sudo tee /etc/apt/sources.list.d/cri-o.sources
 Enabled: yes
 Types: deb
-URIs: https://pkgs.k8s.io/addons:/cri-o:/stable:/v$CRIO_VERSION/deb/
+URIs: https://download.opensuse.org/repositories/isv:/cri-o:/stable:/$CRIO_VERSION/deb/
 Suites: /
 Signed-By: /usr/share/keyrings/cri-o-apt-keyring.gpg
 EOF
 ```
 
 ```bash
-curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/stable:/v$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
+curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/stable:/$CRIO_VERSION/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/cri-o-apt-keyring.gpg
 ```
 
 **3. Update apt and install CRI-O**

--- a/README.md
+++ b/README.md
@@ -319,11 +319,11 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.33.0>"
+K8S_RELEASE="<Release version, e.g. v1.35.4>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.35.4-1.1>"
 ```
 
 ```bash
@@ -364,7 +364,7 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.35.4-1.1>"
 ```
 
 **Step 2. Update bins**

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ EOF
 
 **1. Set variables for subsequent commands**
 ```bash
-export KUBERNETES_VERSION=1.33
-export CRIO_VERSION=1.33
+export KUBERNETES_VERSION=1.35
+export CRIO_VERSION=1.35
 ```
 
 **2. Configure apt certs and repos**
@@ -273,11 +273,11 @@ apt-cache policy kubeadm
 **Step 2. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.33.0>"
+K8S_RELEASE="<Release version, e.g. v1.35.4>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.35.4-1.1>"
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ EOF
 
 **1. Set variables for subsequent commands**
 ```bash
-export KUBERNETES_VERSION=1.31
-export CRIO_VERSION=1.30
+export KUBERNETES_VERSION=1.33
+export CRIO_VERSION=1.33
 ```
 
 **2. Configure apt certs and repos**
@@ -161,7 +161,7 @@ sudo chown -R $(id -u):$(id -g) $HOME/.kube/config
 
 **1. Install Calcio operator**
 ```bash
-kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/refs/heads/release-v3.30/manifests/tigera-operator.yaml
 ```
 
 **2. Apply basic Calico IPIP config
@@ -227,7 +227,7 @@ _Note: You can use kube-vip instead of MetalLB as a Cloud Provider to manage ser
 _Check for latest version [here](https://github.com/metallb/metallb)_
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
 ```
 
 Config:
@@ -273,11 +273,11 @@ apt-cache policy kubeadm
 **Step 2. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.31.0>"
+K8S_RELEASE="<Release version, e.g. v1.33.0>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
 ```
 
 ```bash
@@ -319,11 +319,11 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-K8S_RELEASE="<Release version, e.g. v1.31.0>"
+K8S_RELEASE="<Release version, e.g. v1.33.0>"
 ```
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
 ```
 
 ```bash
@@ -364,7 +364,7 @@ kubectl uncordon $NODE_NAME
 **Step 1. Set environment vars**
 
 ```bash
-KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
+KUBEADM_VER="<kubeadm version, e.g. 1.33.0-00>"
 ```
 
 **Step 2. Update bins**
@@ -372,3 +372,4 @@ KUBEADM_VER="<kubeadm version, e.g. 1.31.0-00>"
 ```bash
 sudo apt-get update && sudo apt-get -y --allow-change-held-packages install kubelet=$KUBEADM_VER kubeadm=$KUBEADM_VER kubectl=$KUBEADM_VER
 ```
+


### PR DESCRIPTION
This PR updates the kuberenetes repo in line with the [deprecation of apt.kuberenetes.io](https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/). At the same time it felt prudent to update the  version to 1.28 and to update Calico, MetalLB and Longhorn to their current latest releases.